### PR TITLE
Ensure multi-story requests return full stories with unified audio

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,12 +198,14 @@ def main() -> None:
         voice = st.text_input("Voice (TTS)", value=config.DEFAULT_TTS_VOICE)
         speech_speed = st.slider("Narration speed", 0.8, 1.2, 1.0, 0.05)
         temperature = st.slider("Creativity", 0.0, 1.0, 0.7, 0.05)
-        story_count = st.slider(
-            "Number of stories",
-            1,
-            3,
-            1,
-            help="Generate multiple variants with the same settings.",
+        story_count = int(
+            st.slider(
+                "Number of stories",
+                1,
+                3,
+                1,
+                help="Generate multiple variants with the same settings.",
+            )
         )
 
     if st.button("Generate reader", type="primary"):

--- a/graded_reader/audio.py
+++ b/graded_reader/audio.py
@@ -18,25 +18,16 @@ class AudioGenerator:
         self.voice = voice
 
     def generate_audio_bundle(self, story: StoryPackage, speed: float = 1.0) -> Dict[str, bytes]:
-        """Create audio files for the full story and each paragraph."""
+        """Create a single audio file narrating the entire story."""
 
         if not self.client:
             return {}
-
-        audio_files: Dict[str, bytes] = {}
 
         full_text = story.primary_text.strip()
         if not full_text:
             return {}
 
-        audio_files["story_full.mp3"] = self._synthesize_audio(full_text, speed=speed)
-
-        for paragraph in story.story:
-            if paragraph.text.strip():
-                filename = f"paragraph_{paragraph.paragraph_id:02d}.mp3"
-                audio_files[filename] = self._synthesize_audio(paragraph.text, speed=speed)
-
-        return audio_files
+        return {"story_full.mp3": self._synthesize_audio(full_text, speed=speed)}
 
     # ------------------------------------------------------------------
     def _synthesize_audio(self, text: str, speed: float = 1.0) -> bytes:


### PR DESCRIPTION
## Summary
- cast the "Number of stories" slider to an integer so multi-story requests are honored during generation
- simplify audio bundle creation to produce a single narration MP3 per story instead of per paragraph

## Testing
- python -m compileall app.py graded_reader

------
https://chatgpt.com/codex/tasks/task_e_68dabad929248332b46d4a89c19e75f7